### PR TITLE
Fix automatic list level repeat

### DIFF
--- a/markups/tail.markup-textile.js
+++ b/markups/tail.markup-textile.js
@@ -240,10 +240,12 @@
             filter: function(_1, _2, _3, _s){
                 var count = this.previousLine();
                 if(count.substr && count.substr(0, 1) === "#"){
-                    count = count.replace(/[^\#]/g, "").split("").length;
+                    count = count.match(/^(\#)+/g);
+                    count = count===null?0:count[0].length;
                     count = (new Array(count)).join("#");
                 } else if(count.substr && count.substr(0, 1) === "*"){
-                    count = count.replace(/[^\*]/g, "").split("").length;
+                    count = count.match(/^(\*)+/g);
+                    count = count===null?0:count[0].length;
                     count = (new Array(count)).join("*");
                 } else {
                     return _2;


### PR DESCRIPTION
When having an input line like `*** *something bold*` and hitting return, the automatic repeat item level insertion fails, due to a to simple regex which counts every occurance of a `*`, leading to additional stars added to the beginning of the next line.

This PR solves this by only matching consecutive stars and sharps.