### PR TITLE
Fix webpack imports for Next.js

### DIFF
--- a/js/tail.writer-full.js
+++ b/js/tail.writer-full.js
@@ -78,7 +78,7 @@
         return position;
     };
     var create = tail.create = function(tag, classes){
-        var r = d.createElement(tag);
+        var r = document.createElement(tag);
             r.className = (classes && classes.join)? classes.join(" "): classes || "";
         return r;
     };
@@ -88,7 +88,7 @@
      |  @since  0.4.0 [0.2.0]
      */
     var writer = function(el, config){
-        el = (typeof(el) == "string")? d.querySelectorAll(el): el;
+        el = (typeof(el) == "string")? document.querySelectorAll(el): el;
         if(el instanceof NodeList || el instanceof HTMLCollection || el instanceof Array){
             for(var _r = [], l = el.length, i = 0; i < l; i++){
                 _r.push(new writer(el[i], clone(config, {})));
@@ -148,7 +148,7 @@
         debug: true,
         disabled: false,
         doubleLineBreak: false,
-        fullscreenParent: d.body,
+        fullscreenParent: null,
         height: [200, 500],
         indentTab: false,
         indentSize: 4,
@@ -338,12 +338,12 @@
             syntax: false,
             action: function(markup, action, type){
                 if(this.con.fullscreenParent === null){
-                    this.con.fullscreenParent = d.body;
+                    this.con.fullscreenParent = document.body;
                 }
 
                 if(!cHAS(this.e.main, "fullscreen")){
                     cADD(this.e.main, "fullscreen");
-                    d.body.style.cssText = "overflow:hidden;";
+                    document.body.style.cssText = "overflow:hidden;";
 
                     this.placeholder = create("DIV");
                     this.placeholder.id = this.e.main.id + "-placeholder";
@@ -352,7 +352,7 @@
                     this.con.fullscreenParent.appendChild(this.e.main);
                 } else {
                     cREM(this.e.main, "fullscreen");
-                    d.body.style.removeProperty("overflow");
+                    document.body.style.removeProperty("overflow");
 
                     this.placeholder.parentElement.replaceChild(this.e.main, this.placeholder);
                     this.placeholder = false;
@@ -2175,7 +2175,7 @@
                         self.update.call(self);
                     });
                 }
-                d.body.onresize = function(){
+                document.body.onresize = function(){
                     self.toolbarResize.call(self);
                 };
 
@@ -2306,9 +2306,9 @@
             } else {
                 this.e.editor.style.height = "250px";
             }
-            var th = w.getComputedStyle(this.e.tools);
+            var th = window.getComputedStyle(this.e.tools);
             th = this.e.tools.offsetHeight + Math.max(parseInt(th.marginTop), 0) + Math.max(parseInt(th.marginBottom), 0);
-            var sh = w.getComputedStyle(this.e.status);
+            var sh = window.getComputedStyle(this.e.status);
             if(typeof(sh) !== "object"){
                 sh = 0;
             } else {

--- a/js/tail.writer.js
+++ b/js/tail.writer.js
@@ -75,7 +75,7 @@
         return position;
     };
     var create = tail.create = function(tag, classes){
-        var r = d.createElement(tag);
+        var r = document.createElement(tag);
             r.className = (classes && classes.join)? classes.join(" "): classes || "";
         return r;
     };
@@ -85,7 +85,7 @@
      |  @since  0.4.0 [0.2.0]
      */
     var writer = function(el, config){
-        el = (typeof(el) == "string")? d.querySelectorAll(el): el;
+        el = (typeof(el) == "string")? document.querySelectorAll(el): el;
         if(el instanceof NodeList || el instanceof HTMLCollection || el instanceof Array){
             for(var _r = [], l = el.length, i = 0; i < l; i++){
                 _r.push(new writer(el[i], clone(config, {})));
@@ -145,7 +145,7 @@
         debug: true,
         disabled: false,
         doubleLineBreak: false,
-        fullscreenParent: d.body,
+        fullscreenParent: null,
         height: [200, 500],
         indentTab: false,
         indentSize: 4,
@@ -335,12 +335,12 @@
             syntax: false,
             action: function(markup, action, type){
                 if(this.con.fullscreenParent === null){
-                    this.con.fullscreenParent = d.body;
+                    this.con.fullscreenParent = document.body;
                 }
 
                 if(!cHAS(this.e.main, "fullscreen")){
                     cADD(this.e.main, "fullscreen");
-                    d.body.style.cssText = "overflow:hidden;";
+                    document.body.style.cssText = "overflow:hidden;";
 
                     this.placeholder = create("DIV");
                     this.placeholder.id = this.e.main.id + "-placeholder";
@@ -349,7 +349,7 @@
                     this.con.fullscreenParent.appendChild(this.e.main);
                 } else {
                     cREM(this.e.main, "fullscreen");
-                    d.body.style.removeProperty("overflow");
+                    document.body.style.removeProperty("overflow");
 
                     this.placeholder.parentElement.replaceChild(this.e.main, this.placeholder);
                     this.placeholder = false;
@@ -792,7 +792,7 @@
                         self.update.call(self);
                     });
                 }
-                d.body.onresize = function(){
+                document.body.onresize = function(){
                     self.toolbarResize.call(self);
                 };
 
@@ -923,9 +923,9 @@
             } else {
                 this.e.editor.style.height = "250px";
             }
-            var th = w.getComputedStyle(this.e.tools);
+            var th = window.getComputedStyle(this.e.tools);
             th = this.e.tools.offsetHeight + Math.max(parseInt(th.marginTop), 0) + Math.max(parseInt(th.marginBottom), 0);
-            var sh = w.getComputedStyle(this.e.status);
+            var sh = window.getComputedStyle(this.e.status);
             if(typeof(sh) !== "object"){
                 sh = 0;
             } else {


### PR DESCRIPTION
These are the changes I made to be able to successfully import tail.writer as a module to fix issue #11. 

#15 doesn't work for me (at least when using with Next.js) because window is undefined in the Node context. 

By removing calls to `d.` and `w.` before any references to the DOM are made, I was able to get the dependency imported at build time, and then am able to call `tail` after the component mounts using `useEffect`. 

```js
import { useEffect } from 'react'
import tail from 'tail.writer'
import marked from 'marked'

export default function TextArea() {
  useEffect(() => {
    window.marked = marked
    tail('.tailwriter-instance', { 
      // ... opts ... 
    })
  }, [])
  
  return (
    <textarea className="tailwriter-instance" />
  )
}

```

I only made changes to `js/tail.writer.js` and `js/tail.writer-full.js`. The other js source files (including the `.min.js` files) would need to be updated too. Would love to hear your thoughts on this approach @SamBrishes 